### PR TITLE
Add `:where` and `:is` selectors

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1147,7 +1147,7 @@
       }
       {
         # Logical / Selector-based
-        'begin': '(?i)((:)(?:not|has|matches))(\\()'
+        'begin': '(?i)((:)(?:not|has|matches|where|is))(\\()'
         'beginCaptures':
           '1':
             'name': 'entity.other.attribute-name.pseudo-class.css'


### PR DESCRIPTION
The logical selectors, `:where` and `:is` are heavily used in WordPress projects, yet are missing from VSCode syntax grammar.