### PR TITLE
Add `text-decoration-thickness` property to CSS grammar

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1537,7 +1537,7 @@
             | scrollbar-color|scrollbar-gutter|scrollbar-width|shape-image-threshold|shape-margin|shape-outside|shape-rendering|size
             | speak-as|src|stop-color|stop-opacity|stroke|stroke-dasharray|stroke-dashoffset|stroke-linecap|stroke-linejoin|stroke-miterlimit
             | stroke-opacity|stroke-width|suffix|symbols|system|tab-size|table-layout|text-align|text-align-last|text-anchor|text-combine-upright
-            | text-decoration|text-decoration-color|text-decoration-line|text-decoration-skip|text-decoration-skip-ink|text-decoration-style
+            | text-decoration|text-decoration-color|text-decoration-line|text-decoration-skip|text-decoration-skip-ink|text-decoration-style|text-decoration-thickness
             | text-emphasis|text-emphasis-color|text-emphasis-position|text-emphasis-style|text-indent|text-justify|text-orientation
             | text-overflow|text-rendering|text-shadow|text-size-adjust|text-transform|text-underline-offset|text-underline-position|top|touch-action|transform
             | transform-box|transform-origin|transform-style|transition|transition-delay|transition-duration|transition-property|transition-timing-function


### PR DESCRIPTION
The `text-decoration-thickness` CSS property is widely supported by browsers.

See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness).