### PR TITLE
Added container at-rule support

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -222,6 +222,44 @@
         ]
       }
       {
+        # @container
+        'begin': '(?i)(?=@container(\\s|\\(|/\\*|$))'
+        'end': '(?<=})(?!\\G)'
+        'patterns': [
+          {
+            'begin': '(?i)\\G(@)container'
+            'beginCaptures':
+              '0':
+                'name': 'keyword.control.at-rule.media.css'
+              '1':
+                'name': 'punctuation.definition.keyword.css'
+            'end': '(?=\\s*[{;])'
+            'name': 'meta.at-rule.media.header.css'
+            'patterns': [
+              {
+                'include': '#media-query-list'
+              }
+            ]
+          }
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.media.begin.bracket.curly.css'
+            'end': '}'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.media.end.bracket.curly.css'
+            'name': 'meta.at-rule.media.body.css'
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+          }
+        ]
+      }
+      {
         # @counter-style
         'begin': '(?i)(?=@counter-style([\\s\'"{;]|/\\*|$))'
         'end': '(?<=})(?!\\G)'


### PR DESCRIPTION
The @container rule is similar enough  (if not down right identical) to the @media rule. Copied and pasted the @media lines, replaced the regex to look for @container instead of @media. All other patterns should work the same, so no need to create new ones.