### PR TITLE
Add `auto-fill` & `auto-fit` for `repeat()` func

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1434,7 +1434,7 @@
       {
         'match': '''(?xi) (?<![\\w-])
           (above|absolute|active|add|additive|after-edge|alias|all|all-petite-caps|all-scroll|all-small-caps|alpha|alphabetic|alternate|alternate-reverse
-          |always|antialiased|auto|auto-pos|available|avoid|avoid-column|avoid-page|avoid-region|backwards|balance|baseline|before-edge|below|bevel
+          |always|antialiased|auto|auto-fill|auto-fit|auto-pos|available|avoid|avoid-column|avoid-page|avoid-region|backwards|balance|baseline|before-edge|below|bevel
           |bidi-override|blink|block|block-axis|block-start|block-end|bold|bolder|border|border-box|both|bottom|bottom-outside|break-all|break-word|bullets
           |butt|capitalize|caption|cell|center|central|char|circle|clip|clone|close-quote|closest-corner|closest-side|col-resize|collapse|color|color-burn
           |color-dodge|column|column-reverse|common-ligatures|compact|condensed|contain|content|content-box|contents|context-menu|contextual|copy|cover


### PR DESCRIPTION
When using an auto-repeat value for the first argument of the `repeat()` function, there are two property keyword options: `auto-fill` and `auto-fit`. 

See https://developer.mozilla.org/en-US/docs/Web/CSS/repeat. 

This commit adds the two keywords for correct syntax highlighting. 