### PR TITLE
Adds new scroll driven Animation properties

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1498,7 +1498,7 @@
           (?:
             # Standard CSS
             accent-color|additive-symbols|align-content|align-items|align-self|all|animation|animation-delay|animation-direction|animation-duration
-            | animation-fill-mode|animation-iteration-count|animation-name|animation-play-state|animation-timing-function|aspect-ratio|backdrop-filter
+            | animation-fill-mode|animation-iteration-count|animation-name|animation-play-state|animation-timing-function|animation-timeline|animation-range|animation-range-start|animation-range-end|aspect-ratio|backdrop-filter
             | backface-visibility|background|background-attachment|background-blend-mode|background-clip|background-color|background-image
             | background-origin|background-position|background-position-[xy]|background-repeat|background-size|bleed|block-size|border
             | border-block-end|border-block-end-color|border-block-end-style|border-block-end-width|border-block-start|border-block-start-color


### PR DESCRIPTION
adds the following CSS properties that are missing:

animation-timeline
animation-range
animation-range-start
animation-range-end

https://drafts.csswg.org/scroll-animations-1/

<img width="339" alt="Screenshot 2024-10-16 at 3 07 55 PM" src="https://github.com/user-attachments/assets/fcaea77c-8c21-49a0-8af3-ce2910e5227b">
