### PR TITLE
Add language extension debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+grammars/css.tmLanguage.json
+testing-util/example.css

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"${workspaceFolder}/testing-util/example.css",
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"preLaunchTask": "prepare-extension-debugging"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "prepare-extension-debugging",
+			"type": "npm",
+			"script": "prepare-extension-debugging",
+			"isBackground": false,
+		},
+	]
+}

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,0 +1,28 @@
+{
+    "comments": {
+        // symbols used for start and end a block comment.
+        "blockComment": [ "/*", "*/" ]
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    // symbols that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "cson": "^8.2.0",
         "vscode-oniguruma": "^2.0.1",
         "vscode-textmate": "^9.0.0"
+      },
+      "engines": {
+        "vscode": "^1.96.0"
       }
     },
     "node_modules/cson": {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,37 @@
   "description": "CSS support in VS Code",
   "version": "0.0.0",
   "scripts": {
+    "prepare-extension-debugging": "node ./testing-util/prepare-extension-debugging.mjs ",
     "test": "node --test ./spec/css-spec.mjs"
   },
   "devDependencies": {
     "cson": "^8.2.0",
     "vscode-oniguruma": "^2.0.1",
     "vscode-textmate": "^9.0.0"
+  },
+  "engines": {
+    "vscode": "^1.96.0"
+  },
+  "contributes": {
+    "languages": [
+      {
+        "id": "css",
+        "aliases": [
+          "CSS",
+          "css"
+        ],
+        "extensions": [
+          ".css"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "css",
+        "scopeName": "source.css",
+        "path": "./grammars/css.tmLanguage.json"
+      }
+    ]
   }
 }

--- a/testing-util/prepare-extension-debugging.mjs
+++ b/testing-util/prepare-extension-debugging.mjs
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+import cson from 'cson';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const file = await fs.promises.readFile(path.join(__dirname, '..', 'grammars', 'css.cson'));
+await fs.promises.writeFile(path.join(__dirname, '..', 'grammars', 'css.tmLanguage.json'), cson.createJSONString(cson.parse(file.toString())));
+
+if (!fs.existsSync(path.join(__dirname, '..', 'testing-util', 'example.css'))) {
+	await fs.promises.writeFile(path.join(__dirname, '..', 'testing-util', 'example.css'), `.foo {\n\tcolor: lime;\n}\n`);
+}


### PR DESCRIPTION
This change adds the needed scaffolding to use the grammer in an extension locally for debugging purposes. Before this change it was only possible to verify changes through unit tests.


https://github.com/user-attachments/assets/c3de13c0-1ec7-41d9-a069-eff793efe288

