### PR TITLE
Fix: Variable name can start with a digit

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1038,10 +1038,9 @@
             'name': 'variable.argument.css'
             'match': '''(?x)
               --
-              (?:[-a-zA-Z_]    | [^\\x00-\\x7F])     # First letter
-              (?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]      # Remainder of identifier
+              (?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]
                 |\\\\(?:[0-9a-fA-F]{1,6}|.)
-              )*
+              )+
             '''
           }
           {
@@ -1702,10 +1701,9 @@
         # Custom properties
         'match': '''(?x) (?<![\\w-])
           --
-          (?:[-a-zA-Z_]    | [^\\x00-\\x7F])     # First letter
           (?:[-a-zA-Z0-9_] | [^\\x00-\\x7F]      # Remainder of identifier
             |\\\\(?:[0-9a-fA-F]{1,6}|.)
-          )*
+          )+
         '''
         'name': 'variable.css'
       }

--- a/spec/css-spec.mjs
+++ b/spec/css-spec.mjs
@@ -2463,6 +2463,12 @@ describe('CSS grammar', function () {
 			assert.deepStrictEqual(tokens[5], { scopes: ['source.css', 'meta.property-list.css', 'variable.css'], value: '--white' });
 		});
 
+		it('tokenizes custom properties with a leading digit', function () {
+			var tokens;
+			tokens = testGrammar.tokenizeLine('[data-test] { --4-grid-columns: calc(4 * var(--column-and-gap-width)); }').tokens;
+			assert.deepStrictEqual(tokens[6], { scopes: ['source.css', 'meta.property-list.css', 'variable.css'], value: '--4-grid-columns' });
+		});
+
 		it('tokenises commas between property values', function () {
 			var tokens;
 			tokens = testGrammar.tokenizeLine('a{ text-shadow: a, b; }').tokens;
@@ -2554,6 +2560,13 @@ describe('CSS grammar', function () {
 				var tokens;
 				tokens = testGrammar.tokenizeLine('div { color: var(--primary-color) }').tokens;
 				assert.deepStrictEqual(tokens[9], { scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.variable.css', 'variable.argument.css'], value: '--primary-color' });
+			});
+
+			it('tokenizes custom variables with a leading digit', function () {
+				var tokens;
+				tokens = testGrammar.tokenizeLine('.flex { grid-template-columns: var(--7-grid-columns-minus-last-gap) var(--4-grid-columns); }').tokens;
+				assert.deepStrictEqual(tokens[10], { scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.variable.css', 'variable.argument.css'], value: '--7-grid-columns-minus-last-gap' });
+				assert.deepStrictEqual(tokens[15], { scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'meta.function.variable.css', 'variable.argument.css'], value: '--4-grid-columns' });
 			});
 
 			it('tokenises numeric values correctly', function () {


### PR DESCRIPTION
According to the spec, an [`<ident-token>`](url) cannot start with a digit. However, for variables that begin with a double-hyphen `--`, the name following it CAN start with a digit.

![](https://github.com/user-attachments/assets/14bcdf20-05e6-4e36-a201-ae3268e8a237)


For example, `--7-grid-columns-minus-last-gap` (found by @yzqzss in [GitHub's landing page](https://github.githubassets.com/assets/landing-pages-6fbc3e78c091.css)) is a completely valid variable name.

Current grammar does not properly highlight it:

![](https://github.com/user-attachments/assets/170edbc5-bb83-485b-8111-3c9946fcaced)


This change to the lexical grammar was made in 2014, although they didn't mention it clearly:

> Change the definition of ident-like tokens to allow `"--"` to start an ident. As part of this, rearrange the ordering of the clauses in the `"-"` step of [consume a token](https://www.w3.org/TR/css-syntax-3/#consume-a-token) so that [<CDC-token>](https://www.w3.org/TR/css-syntax-3/#typedef-cdc-token)s are recognized as such instead of becoming a -- [<ident-token>](https://www.w3.org/TR/css-syntax-3/#typedef-ident-token).

The old definition:

![](https://github.com/user-attachments/assets/f0be6962-888c-4d83-93b3-ab5cb9b9e7ed)